### PR TITLE
flounder: remove build_id override

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -44,8 +44,7 @@ DEVICE_PACKAGE_OVERLAYS += device/htc/flounder/overlay-cm
 PRODUCT_BUILD_PROP_OVERRIDES += \
     PRODUCT_NAME=flounder \
     BUILD_FINGERPRINT=google/volantis/flounder:7.1.1/NMF26F/3425388:user/release-keys \
-    PRIVATE_BUILD_DESC="volantis-user 7.1.1 NMF26F 3425388 release-keys" \
-    BUILD_ID=NMF26F
+    PRIVATE_BUILD_DESC="volantis-user 7.1.1 NMF26F 3425388 release-keys"
 
 ## Device identifier. This must come after all inclusions
 PRODUCT_NAME := cm_flounder


### PR DESCRIPTION
No longer needed since we changed to having verity on user builds only.

This partially reverts commit a8c0cc89c501fb207a9a850b9b9d1008d58c7b2a.

Change-Id: Ida5b03c8eb0c228ca2871d68fcaba5bb82def3d3